### PR TITLE
added test for dont cache empty results

### DIFF
--- a/core_lib/cache/cache_decorator.py
+++ b/core_lib/cache/cache_decorator.py
@@ -75,11 +75,8 @@ class Cache(object):
                 result = cache_handler.get(key)
                 if result is None:
                     result = func(*args, **kwargs)
-                    if self.cache_empty_result and result is not None:
+                    if (self.cache_empty_result and result is not None) or result:
                         cache_handler.set(key, result, _get_expire(self.expire))
-                    else:
-                        if result:
-                            cache_handler.set(key, result, _get_expire(self.expire))
                 return result
 
         return __wrapper

--- a/core_lib/cache/cache_decorator.py
+++ b/core_lib/cache/cache_decorator.py
@@ -43,13 +43,13 @@ class Cache(object):
         max_key_length: int = 250,
         expire: Union[timedelta, str] = None,
         invalidate: bool = False,
-        handler: str = None,
+        handler_name: str = None,
         cache_empty_result: bool = True,
     ):
         self.key = key
         self.max_key_length = max_key_length
         self.invalidate = invalidate
-        self.handler_name = handler
+        self.handler_name = handler_name
         self.expire = _get_expire(expire)
         self.cache_empty_result = cache_empty_result
 

--- a/core_lib/cache/cache_decorator.py
+++ b/core_lib/cache/cache_decorator.py
@@ -43,8 +43,8 @@ class Cache(object):
         max_key_length: int = 250,
         expire: Union[timedelta, str] = None,
         invalidate: bool = False,
-        cache_empty_result: bool = True,
         handler: str = None,
+        cache_empty_result: bool = True,
     ):
         self.key = key
         self.max_key_length = max_key_length

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -245,7 +245,7 @@ class TestCache(unittest.TestCase):
 
     CACHE_WITH_PARAMS = 'test_cache_param_{param_1}'
 
-    @Cache(key=CACHE_WITH_PARAMS, expire=timedelta(seconds=2), handler=cache_client_name)
+    @Cache(key=CACHE_WITH_PARAMS, expire=timedelta(seconds=2), handler_name=cache_client_name)
     def get_cache_with_param(self, param_1):
         return TestCache.test_value
 
@@ -259,11 +259,11 @@ class TestCache(unittest.TestCase):
     def get_cache_with_param_optional(self, param_1, param_2=2, param_3=None, param_4="param4"):
         return TestCache.test_value
 
-    @Cache(key=CACHE_WITH_PARAMS_OPTIONAL, invalidate=True, handler=cache_client_name)
+    @Cache(key=CACHE_WITH_PARAMS_OPTIONAL, invalidate=True, handler_name=cache_client_name)
     def clear_cache_with_param_optional(self, param_1, param_2=2, param_3=None, param_4="param4"):
         pass
 
-    @Cache(key=CACHE_TEST, expire=timedelta(seconds=2), handler="sosososos")
+    @Cache(key=CACHE_TEST, expire=timedelta(seconds=2), handler_name="sosososos")
     def not_exists_cache_client_name(self):
         return TestCache.test_value
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -277,6 +277,8 @@ class TestCache(unittest.TestCase):
         self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
         with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
             self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {})
+        TestCache.test_dict = {'value': '100'}
+        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
 
         # Tuple
         self.clear_cache_empty_false()
@@ -288,6 +290,8 @@ class TestCache(unittest.TestCase):
         self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
         with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
             self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ())
+        TestCache.test_tuple = ('value', '100')
+        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
 
         # List
         self.clear_cache_empty_false()
@@ -299,6 +303,8 @@ class TestCache(unittest.TestCase):
         self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
         with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
             self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), [])
+        TestCache.test_list = ['value', '100']
+        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
 
         # String
         self.clear_cache_empty_false()
@@ -310,6 +316,8 @@ class TestCache(unittest.TestCase):
         self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
         with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
             self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "")
+        TestCache.test_string = "Hello World"
+        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
 
         # Set
         self.clear_cache_empty_false()
@@ -321,6 +329,8 @@ class TestCache(unittest.TestCase):
         self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
         with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
             self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), set())
+        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
+        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
 
     @Cache(key="test_cache_1", expire=timedelta(seconds=2))
     def get_cache(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,11 +13,11 @@ cache_client_name = "xyz"
 
 class TestCache(unittest.TestCase):
     test_value = 100
-    test_dict = {}
-    test_tuple = ()
-    test_list = []
-    test_string = ""
-    test_set = set()
+    test_dict = {'value': '100'}
+    test_tuple = ('value', '100')
+    test_list = ['value', '100']
+    test_string = "Hello World"
+    test_set = {1.0, "Hello", (1, 2, 3)}
 
     @classmethod
     def setUpClass(cls):
@@ -30,7 +30,7 @@ class TestCache(unittest.TestCase):
     def test_cache_client_register(self):
         self.assertRaises(ValueError, self.not_exists_cache_client_name)
 
-    def test_cash(self):
+    def test_cache(self):
         self.clear_cache()
         TestCache.test_value = 100
         self.assertEqual(self.get_cache(), 100)
@@ -43,7 +43,7 @@ class TestCache(unittest.TestCase):
         self.clear_cache()
         self.assertEqual(self.get_cache(), 100)
 
-    def test_cash_with_param(self):
+    def test_cache_with_param(self):
         TestCache.test_value = 100
 
         param = "some_val"
@@ -59,7 +59,7 @@ class TestCache(unittest.TestCase):
         self.clear_cache_with_param(param)
         self.assertEqual(self.get_cache_with_param(param), 100)
 
-    def test_cash_with_param_optional(self):
+    def test_cache_with_param_optional(self):
         TestCache.test_value = 100
 
         param = "some_val"
@@ -92,7 +92,7 @@ class TestCache(unittest.TestCase):
         TestCache.test_value = 800
         self.assertEqual(self.get_cache_with_param_optional(param, 4, 5, "__2"), 800)
 
-    def test_cash_only_param_optional(self):
+    def test_cache_only_param_optional(self):
         TestCache.test_value = 100
         self.assertEqual(self.get_cache_only_param_optional(), 100)
         TestCache.test_value = 200
@@ -200,238 +200,164 @@ class TestCache(unittest.TestCase):
         TestCache.test_value = 100
         self.assertEqual(self.get_cache_expire_string_year(), 100)
 
+    def _test_empty_cache_helper(self, cache_data, empty_value, cache_empty_results):
+        if cache_empty_results:
+            self.clear_cache_empty()
+            self.assertEqual(self.get_cache_empty_results(empty_value), empty_value)
+            self.assertEqual(self.get_cache_empty_results(cache_data), empty_value)
+            with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+                self.assertEqual(self.get_cache_empty_results(cache_data), cache_data)
+            self.assertEqual(self.get_cache_empty_results(empty_value), cache_data)
+            with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+                self.assertEqual(self.get_cache_empty_results(empty_value), empty_value)
+        else:
+            self.clear_cache_empty_false()
+            self.assertEqual(self.get_dont_cache_empty_results(empty_value), empty_value)
+            self.assertEqual(self.get_dont_cache_empty_results(cache_data), cache_data)
+            TestCache.test_dict = {}
+            self.assertEqual(self.get_dont_cache_empty_results(empty_value), cache_data)
+            with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+                self.assertEqual(self.get_dont_cache_empty_results(empty_value), empty_value)
+            self.assertEqual(self.get_dont_cache_empty_results(cache_data), cache_data)
+
     def test_cache_empty(self):
-        # Dict
-        self.clear_cache_empty()
-        TestCache.test_dict = {}
-        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
-        TestCache.test_dict = {'value': '100'}
-        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {'value': '100'})
-        TestCache.test_dict = {}
-        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {'value': '100'})
-        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
-            self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
-
-        # Tuple
-        self.clear_cache_empty()
-        TestCache.test_tuple = ()
-        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
-        TestCache.test_tuple = ('value', '100')
-        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ('value', '100'))
-        TestCache.test_tuple = ()
-        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ('value', '100'))
-        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
-            self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
-
-        # List
-        self.clear_cache_empty()
-        TestCache.test_list = []
-        self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
-        TestCache.test_list = ['value', '100']
-        self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertListEqual(self.get_cache_empty(TestCache.test_list), ['value', '100'])
-        TestCache.test_list = []
-        self.assertListEqual(self.get_cache_empty(TestCache.test_list), ['value', '100'])
-        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
-            self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
-
-        # String
-        self.clear_cache_empty()
-        TestCache.test_string = ""
-        self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
-        TestCache.test_string = "Hello World"
-        self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertEqual(self.get_cache_empty(TestCache.test_string), "Hello World")
-        TestCache.test_string = ""
-        self.assertEqual(self.get_cache_empty(TestCache.test_string), "Hello World")
-        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
-            self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
-
-        # Set
-        self.clear_cache_empty()
-        TestCache.test_set = set()
-        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
-        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
-        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertSetEqual(self.get_cache_empty(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
-        TestCache.test_set = set()
-        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
-        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
-            self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
+        self._test_empty_cache_helper(TestCache.test_dict, {}, True)
+        self._test_empty_cache_helper(TestCache.test_tuple, (), True)
+        self._test_empty_cache_helper(TestCache.test_list, [], True)
+        self._test_empty_cache_helper(TestCache.test_string, "", True)
+        self._test_empty_cache_helper(TestCache.test_set, set(), True)
 
     def test_cache_empty_false(self):
-        # Dict
-        self.clear_cache_empty_false()
-        TestCache.test_dict = {}
-        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {})
-        TestCache.test_dict = {'value': '100'}
-        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
-        TestCache.test_dict = {}
-        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {})
-        TestCache.test_dict = {'value': '100'}
-        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
+        self._test_empty_cache_helper(TestCache.test_dict, {}, False)
+        self._test_empty_cache_helper(TestCache.test_tuple, (), False)
+        self._test_empty_cache_helper(TestCache.test_list, [], False)
+        self._test_empty_cache_helper(TestCache.test_string, "", False)
+        self._test_empty_cache_helper(TestCache.test_set, set(), False)
 
-        # Tuple
-        self.clear_cache_empty_false()
-        TestCache.test_tuple = ()
-        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ())
-        TestCache.test_tuple = ('value', '100')
-        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
-        TestCache.test_tuple = ()
-        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ())
-        TestCache.test_tuple = ('value', '100')
-        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
+    CACHE_TEST = 'test_cache_1'
 
-        # List
-        self.clear_cache_empty_false()
-        TestCache.test_list = []
-        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), [])
-        TestCache.test_list = ['value', '100']
-        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
-        TestCache.test_list = []
-        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), [])
-        TestCache.test_list = ['value', '100']
-        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
-
-        # String
-        self.clear_cache_empty_false()
-        TestCache.test_string = ""
-        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "")
-        TestCache.test_string = "Hello World"
-        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
-        TestCache.test_string = ""
-        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "")
-        TestCache.test_string = "Hello World"
-        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
-
-        # Set
-        self.clear_cache_empty_false()
-        TestCache.test_set = set()
-        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), set())
-        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
-        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
-        TestCache.test_set = set()
-        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
-        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
-            self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), set())
-        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
-        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
-
-    @Cache(key="test_cache_1", expire=timedelta(seconds=2))
+    @Cache(key=CACHE_TEST, expire=timedelta(seconds=2))
     def get_cache(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_1", invalidate=True)
+    @Cache(key=CACHE_TEST, invalidate=True)
     def clear_cache(self):
         pass
 
-    @Cache(key="test_cache_param_{param_1}", expire=timedelta(seconds=2), handler=cache_client_name)
+    CACHE_WITH_PARAMS = 'test_cache_param_{param_1}'
+
+    @Cache(key=CACHE_WITH_PARAMS, expire=timedelta(seconds=2), handler=cache_client_name)
     def get_cache_with_param(self, param_1):
         return TestCache.test_value
 
-    @Cache(key="test_cache_param_{param_1}", invalidate=True)
+    @Cache(key=CACHE_WITH_PARAMS, invalidate=True)
     def clear_cache_with_param(self, param_1):
         pass
 
-    @Cache(key="test_cache_param_{param_1}{param_2}{param_3}{param_4}", expire=timedelta(seconds=2))
+    CACHE_WITH_PARAMS_OPTIONAL = 'test_cache_param_{param_1}{param_2}{param_3}{param_4}'
+
+    @Cache(key=CACHE_WITH_PARAMS_OPTIONAL, expire=timedelta(seconds=2))
     def get_cache_with_param_optional(self, param_1, param_2=2, param_3=None, param_4="param4"):
         return TestCache.test_value
 
-    @Cache(key="test_cache_param_{param_1}{param_2}{param_3}{param_4}", invalidate=True, handler=cache_client_name)
+    @Cache(key=CACHE_WITH_PARAMS_OPTIONAL, invalidate=True, handler=cache_client_name)
     def clear_cache_with_param_optional(self, param_1, param_2=2, param_3=None, param_4="param4"):
         pass
 
-    @Cache(key="test_cache_1", expire=timedelta(seconds=2), handler="sosososos")
+    @Cache(key=CACHE_TEST, expire=timedelta(seconds=2), handler="sosososos")
     def not_exists_cache_client_name(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_param_{param_1}{param_2}{param_3}{param_4}", expire=timedelta(seconds=2))
+    @Cache(key=CACHE_WITH_PARAMS_OPTIONAL, expire=timedelta(seconds=2))
     def get_cache_only_param_optional(self, param_1=None, param_2=None, param_3=None, param_4=None):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_seconds", expire="2 second")
+    CACHE_EXP_STR_SECONDS = 'test_cache_expire_string_seconds'
+
+    @Cache(key=CACHE_EXP_STR_SECONDS, expire="2 second")
     def get_cache_expire_string_seconds(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_seconds", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_SECONDS, invalidate=True)
     def clear_cache_expire_string_seconds(self):
         pass
 
-    @Cache(key="test_cache_expire_string_minute", expire="1 minute")
+    CACHE_EXP_STR_MINUTES = 'test_cache_expire_string_minute'
+
+    @Cache(key=CACHE_EXP_STR_MINUTES, expire="1 minute")
     def get_cache_expire_string_minute(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_minute", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_MINUTES, invalidate=True)
     def clear_cache_expire_string_minute(self):
         pass
 
-    @Cache(key="test_cache_expire_string_hour", expire="1 hour")
+    CACHE_EXP_STR_HOUR = 'test_cache_expire_string_hour'
+
+    @Cache(key=CACHE_EXP_STR_HOUR, expire="1 hour")
     def get_cache_expire_string_hour(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_hour", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_HOUR, invalidate=True)
     def clear_cache_expire_string_hour(self):
         pass
 
-    @Cache(key="test_cache_expire_string_day", expire="1 day")
+    CACHE_EXP_STR_DAY = 'test_cache_expire_string_day'
+
+    @Cache(key=CACHE_EXP_STR_DAY, expire="1 day")
     def get_cache_expire_string_day(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_day", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_DAY, invalidate=True)
     def clear_cache_expire_string_day(self):
         pass
 
-    @Cache(key="test_cache_expire_string_week", expire="1 week")
+    CACHE_EXP_STR_WEEK = 'test_cache_expire_string_week'
+
+    @Cache(key=CACHE_EXP_STR_WEEK, expire="1 week")
     def get_cache_expire_string_week(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_week", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_WEEK, invalidate=True)
     def clear_cache_expire_string_week(self):
         pass
 
-    @Cache(key="test_cache_expire_string_month", expire="1 month")
+    CACHE_EXP_STR_MONTH = 'test_cache_expire_string_month'
+
+    @Cache(key=CACHE_EXP_STR_MONTH, expire="1 month")
     def get_cache_expire_string_month(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_month", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_MONTH, invalidate=True)
     def clear_cache_expire_string_month(self):
         pass
 
-    @Cache(key="test_cache_expire_string_year", expire="1 year")
+    CACHE_EXP_STR_YEAR = 'test_cache_expire_string_year'
+
+    @Cache(key=CACHE_EXP_STR_YEAR, expire="1 year")
     def get_cache_expire_string_year(self):
         return TestCache.test_value
 
-    @Cache(key="test_cache_expire_string_year", invalidate=True)
+    @Cache(key=CACHE_EXP_STR_YEAR, invalidate=True)
     def clear_cache_expire_string_year(self):
         pass
 
-    @Cache(key="test_cache_empty", expire=timedelta(seconds=2))
-    def get_cache_empty(self, param):
+    CACHE_EMPTY_RESULTS = 'test_cache_empty_results'
+
+    @Cache(key=CACHE_EMPTY_RESULTS, expire=timedelta(seconds=2))
+    def get_cache_empty_results(self, param):
         return param
 
-    @Cache(key="test_cache_empty", invalidate=True)
+    @Cache(key=CACHE_EMPTY_RESULTS, invalidate=True)
     def clear_cache_empty(self):
         pass
 
-    @Cache(key="test_cache_empty_false", cache_empty_result=False, expire=timedelta(seconds=2))
-    def get_cache_empty_false(self, param):
+    CACHE_EMPTY_RESULTS_FALSE = 'test_cache_empty_results_false'
+
+    @Cache(key=CACHE_EMPTY_RESULTS_FALSE, cache_empty_result=False, expire=timedelta(seconds=2))
+    def get_dont_cache_empty_results(self, param):
         return param
 
-    @Cache(key="test_cache_empty_false", invalidate=True)
+    @Cache(key=CACHE_EMPTY_RESULTS_FALSE, invalidate=True)
     def clear_cache_empty_false(self):
         pass

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -214,7 +214,6 @@ class TestCache(unittest.TestCase):
             self.clear_cache_empty_false()
             self.assertEqual(self.get_dont_cache_empty_results(empty_value), empty_value)
             self.assertEqual(self.get_dont_cache_empty_results(cache_data), cache_data)
-            TestCache.test_dict = {}
             self.assertEqual(self.get_dont_cache_empty_results(empty_value), cache_data)
             with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
                 self.assertEqual(self.get_dont_cache_empty_results(empty_value), empty_value)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,6 +13,11 @@ cache_client_name = "xyz"
 
 class TestCache(unittest.TestCase):
     test_value = 100
+    test_dict = {}
+    test_tuple = ()
+    test_list = []
+    test_string = ""
+    test_set = set()
 
     @classmethod
     def setUpClass(cls):
@@ -195,6 +200,128 @@ class TestCache(unittest.TestCase):
         TestCache.test_value = 100
         self.assertEqual(self.get_cache_expire_string_year(), 100)
 
+    def test_cache_empty(self):
+        # Dict
+        self.clear_cache_empty()
+        TestCache.test_dict = {}
+        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
+        TestCache.test_dict = {'value': '100'}
+        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {'value': '100'})
+        TestCache.test_dict = {}
+        self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {'value': '100'})
+        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+            self.assertDictEqual(self.get_cache_empty(TestCache.test_dict), {})
+
+        # Tuple
+        self.clear_cache_empty()
+        TestCache.test_tuple = ()
+        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
+        TestCache.test_tuple = ('value', '100')
+        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ('value', '100'))
+        TestCache.test_tuple = ()
+        self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ('value', '100'))
+        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+            self.assertTupleEqual(self.get_cache_empty(TestCache.test_tuple), ())
+
+        # List
+        self.clear_cache_empty()
+        TestCache.test_list = []
+        self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
+        TestCache.test_list = ['value', '100']
+        self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertListEqual(self.get_cache_empty(TestCache.test_list), ['value', '100'])
+        TestCache.test_list = []
+        self.assertListEqual(self.get_cache_empty(TestCache.test_list), ['value', '100'])
+        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+            self.assertListEqual(self.get_cache_empty(TestCache.test_list), [])
+
+        # String
+        self.clear_cache_empty()
+        TestCache.test_string = ""
+        self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
+        TestCache.test_string = "Hello World"
+        self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertEqual(self.get_cache_empty(TestCache.test_string), "Hello World")
+        TestCache.test_string = ""
+        self.assertEqual(self.get_cache_empty(TestCache.test_string), "Hello World")
+        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+            self.assertEqual(self.get_cache_empty(TestCache.test_string), "")
+
+        # Set
+        self.clear_cache_empty()
+        TestCache.test_set = set()
+        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
+        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
+        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertSetEqual(self.get_cache_empty(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
+        TestCache.test_set = set()
+        self.assertSetEqual(self.get_cache_empty(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
+        with freeze_time(datetime.utcnow() + timedelta(seconds=4)):
+            self.assertSetEqual(self.get_cache_empty(TestCache.test_set), set())
+
+    def test_cache_empty_false(self):
+        # Dict
+        self.clear_cache_empty_false()
+        TestCache.test_dict = {}
+        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {})
+        TestCache.test_dict = {'value': '100'}
+        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
+        TestCache.test_dict = {}
+        self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {'value': '100'})
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertDictEqual(self.get_cache_empty_false(TestCache.test_dict), {})
+
+        # Tuple
+        self.clear_cache_empty_false()
+        TestCache.test_tuple = ()
+        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ())
+        TestCache.test_tuple = ('value', '100')
+        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
+        TestCache.test_tuple = ()
+        self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ('value', '100'))
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertTupleEqual(self.get_cache_empty_false(TestCache.test_tuple), ())
+
+        # List
+        self.clear_cache_empty_false()
+        TestCache.test_list = []
+        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), [])
+        TestCache.test_list = ['value', '100']
+        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
+        TestCache.test_list = []
+        self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), ['value', '100'])
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertListEqual(self.get_cache_empty_false(TestCache.test_list), [])
+
+        # String
+        self.clear_cache_empty_false()
+        TestCache.test_string = ""
+        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "")
+        TestCache.test_string = "Hello World"
+        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
+        TestCache.test_string = ""
+        self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "Hello World")
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertEqual(self.get_cache_empty_false(TestCache.test_string), "")
+
+        # Set
+        self.clear_cache_empty_false()
+        TestCache.test_set = set()
+        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), set())
+        TestCache.test_set = {1.0, "Hello", (1, 2, 3)}
+        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
+        TestCache.test_set = set()
+        self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), {1.0, "Hello", (1, 2, 3)})
+        with freeze_time(datetime.utcnow() + timedelta(seconds=2)):
+            self.assertSetEqual(self.get_cache_empty_false(TestCache.test_set), set())
+
     @Cache(key="test_cache_1", expire=timedelta(seconds=2))
     def get_cache(self):
         return TestCache.test_value
@@ -281,4 +408,20 @@ class TestCache(unittest.TestCase):
 
     @Cache(key="test_cache_expire_string_year", invalidate=True)
     def clear_cache_expire_string_year(self):
+        pass
+
+    @Cache(key="test_cache_empty", expire=timedelta(seconds=2))
+    def get_cache_empty(self, param):
+        return param
+
+    @Cache(key="test_cache_empty", invalidate=True)
+    def clear_cache_empty(self):
+        pass
+
+    @Cache(key="test_cache_empty_false", cache_empty_result=False, expire=timedelta(seconds=2))
+    def get_cache_empty_false(self, param):
+        return param
+
+    @Cache(key="test_cache_empty_false", invalidate=True)
+    def clear_cache_empty_false(self):
         pass

--- a/tests/test_default_registry.py
+++ b/tests/test_default_registry.py
@@ -266,11 +266,11 @@ class TestDefaultRegistry(unittest.TestCase):
         customer_c = Customer()
         customer_registry.register('customer_c', customer_c)
 
-        self.assertEquals(customer_registry.get('customer_a'), customer_a)
-        self.assertEquals(customer_registry.get('customer_b'), customer_b)
-        self.assertEquals(customer_registry.get('customer_c'), customer_c)
+        self.assertEqual(customer_registry.get('customer_a'), customer_a)
+        self.assertEqual(customer_registry.get('customer_b'), customer_b)
+        self.assertEqual(customer_registry.get('customer_c'), customer_c)
 
-        self.assertEquals(customer_registry.get(), customer_b)
+        self.assertEqual(customer_registry.get(), customer_b)
         self.assertNotEqual(customer_registry.get(), customer_a)
         self.assertNotEqual(customer_registry.get(), customer_c)
 

--- a/website/docs/cache.md
+++ b/website/docs/cache.md
@@ -81,7 +81,7 @@ class Cache(object):
 * `expire` Period of time when the value is expired.
 * `invalidate` Remove the value from the cache using the key.
 * `handler` name of the handler to be used for handling the cache, by default `Core-Lib`'s default `CacheHandler` is used.
-* `cache_empty_result` type `bool`, default `True`, is responsible for caching the empty values like `{}`, `[]`, `()`, `""` and `set()`.
+* `cache_empty_result` type `bool`, default `True`, when `True`, will cache empty values as `{}`, `[]`, `()`, `""` and `set()`.
 
 
 ### Cache Initialization

--- a/website/docs/cache.md
+++ b/website/docs/cache.md
@@ -61,7 +61,15 @@ cache_client_factory.get() # returns None. Multiple client registered.
 ```python
 class Cache(object):
     ...
-    def __init__(self, key: str = None, expire: timedelta = None, invalidate: bool = False, cache_client_name: str = None):
+    def __init__(
+        self,
+        key: str = None,
+        max_key_length: int = 250,
+        expire: Union[timedelta, str] = None,
+        invalidate: bool = False,
+        handler: str = None,
+        cache_empty_result: bool = True,
+    ):
 ```
 * `key` The key used to store the value. possible values are:
    
@@ -69,9 +77,11 @@ class Cache(object):
     
     `some_key{param_1}{param_2}`: will build a key with the `param_1` and `param_2` values.     
     when a parameter is optional and empty `_` is used. 
+* `max_key_length` default `250`, the maximum length of key string to be accepted by decorator.
 * `expire` Period of time when the value is expired.
 * `invalidate` Remove the value from the cache using the key.
-* `cache_client_name` The name to pay to get the correct `CacheHandler`.
+* `handler` name of the handler to be used for handling the cache, by default `Core-Lib`'s default `CacheHandler` is used.
+* `cache_empty_result` type `bool`, default `True`, is responsible for caching the empty values like `{}`, `[]`, `()`, `""` and `set()`.
 
 
 ### Cache Initialization

--- a/website/docs/cache.md
+++ b/website/docs/cache.md
@@ -67,7 +67,7 @@ class Cache(object):
         max_key_length: int = 250,
         expire: Union[timedelta, str] = None,
         invalidate: bool = False,
-        handler: str = None,
+        handler_name: str = None,
         cache_empty_result: bool = True,
     ):
 ```
@@ -80,7 +80,7 @@ class Cache(object):
 * `max_key_length` default `250`, the maximum length of key string to be accepted by decorator.
 * `expire` Period of time when the value is expired.
 * `invalidate` Remove the value from the cache using the key.
-* `handler` name of the handler to be used for handling the cache, by default `Core-Lib`'s default `CacheHandler` is used.
+* `handler_name` name of the handler, will specify what `CacheHandler` to use, using the `CoreLib.cache_registry`.
 * `cache_empty_result` type `bool`, default `True`, when `True`, will cache empty values as `{}`, `[]`, `()`, `""` and `set()`.
 
 


### PR DESCRIPTION
fixed a warning for `assertEquals` to `assertEqual` for default registry test